### PR TITLE
Document scipy and tkinter dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project would not be possible without the following libraries: Numpy for nu
 
 ## Instructions:
 
-Make sure that you have at least Python 3.6.5 with Numpy, Matplotlib and Sympy installed. Install these by running `pip3 install numpy matplotlib sympy`.  You may also optionally install Numba, which improves performance.  To install Numba, run `pip3 install numba`.
+Make sure that you have at least Python 3.6.5 with Numpy, Matplotlib, Sympy and Scipy installed. Install these by running `pip3 install numpy matplotlib sympy scipy`. TKinter is also required and (on some Linux distributions) it can be installed with `sudo apt-get install python3-tk`.  You may also optionally install Numba, which improves performance.  To install Numba, run `pip3 install numba`.
 
 Obtain all the necessary code by cloning this repository or downloading it, then run the file `app.py`. You should see something like:
 

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -3,6 +3,7 @@
 numpy >= 1.14.2
 sympy >= 1.1.1
 matplotlib >= 2.2.2
+scipy >= 1.5.2
 #tkinter >= 8.6
 
 #The following is actually 


### PR DESCRIPTION
Hi marl0ny,

Thank you for making this simulation. I had enjoyed interacting with it.

On my machine, I was not able to run the software initially: I encountered a `scipy 0.16+ is required for linear algebra` error and (after installing `scipy`) I got a `ModuleNotFoundError: No module named 'tkinter'` error.

This pull request mentions `scipy` and `tkinter` in the README and suggests a way for users to install TKinter which works on Ubuntu.
